### PR TITLE
Make some dependencies optional

### DIFF
--- a/acstools/acs2d.py
+++ b/acstools/acs2d.py
@@ -31,10 +31,6 @@ try:
     from stsci.tools import parseinput
 except ImportError:  # So RTD would build
     pass
-try:
-    from stsci.tools import teal
-except:
-    teal = None
 
 __taskname__ = "acs2d"
 __version__ = "2.0"

--- a/acstools/acs2d.py
+++ b/acstools/acs2d.py
@@ -26,12 +26,6 @@ In Pyraf::
 import os
 import subprocess
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-except ImportError:  # So RTD would build
-    pass
-
 __taskname__ = "acs2d"
 __version__ = "2.0"
 __vdate__ = "10-Oct-2014"
@@ -83,6 +77,8 @@ def acs2d(input, exec_path='', time_stamps=False, verbose=False, quiet=False):
         Set to True for quiet output.
 
     """
+    from stsci.tools import parseinput  # Optional package dependency
+
     if exec_path:
         if not os.path.exists(exec_path):
             raise OSError('Executable not found: ' + exec_path)

--- a/acstools/acs_destripe.py
+++ b/acstools/acs_destripe.py
@@ -63,7 +63,6 @@ from astropy.io import fits
 # STSCI
 try:
     from stsci.tools import parseinput
-    from stsci.tools import teal
     from stsci.tools import bitmask
     from stsci.imagestats import ImageStats
 except ImportError:  # So RTD would build

--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -86,7 +86,6 @@ import numpy as np
 # STSCI
 try:
     from stsci.tools import parseinput
-    from stsci.tools import teal
     from stsci.tools import bitmask
 except ImportError:  # So RTD would build
     pass

--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -83,13 +83,6 @@ from astropy.time import Time
 # THIRD-PARTY
 import numpy as np
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-    from stsci.tools import bitmask
-except ImportError:  # So RTD would build
-    pass
-
 # LOCAL
 from . import acs_destripe
 from . import acs2d
@@ -267,6 +260,9 @@ def destripe_plus(inputfile, suffix='strp', stat='pmode1', maxiter=15,
 
     Raises
     ------
+    ImportError
+        ``stsci.tools`` not found.
+
     IOError
         Input file does not exist.
 
@@ -274,6 +270,10 @@ def destripe_plus(inputfile, suffix='strp', stat='pmode1', maxiter=15,
         Invalid header values or CALACS version.
 
     """
+    # Optional package dependencies
+    from stsci.tools import parseinput
+    from stsci.tools import bitmask
+
     # process input file(s) and if we have multiple input files - recursively
     # call acs_destripe_plus for each input image:
     flist = parseinput.parseinput(inputfile)[0]

--- a/acstools/acsccd.py
+++ b/acstools/acsccd.py
@@ -30,12 +30,6 @@ In Pyraf::
 import os
 import subprocess
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-except ImportError:  # So RTD would build
-    pass
-
 __taskname__ = "acsccd"
 __version__ = "2.0"
 __vdate__ = "13-Aug-2013"
@@ -85,6 +79,8 @@ def acsccd(input, exec_path='', time_stamps=False, verbose=False, quiet=False):
         Set to True for quiet output.
 
     """
+    from stsci.tools import parseinput  # Optional package dependency
+
     if exec_path:
         if not os.path.exists(exec_path):
             raise OSError('Executable not found: ' + exec_path)

--- a/acstools/acsccd.py
+++ b/acstools/acsccd.py
@@ -35,10 +35,6 @@ try:
     from stsci.tools import parseinput
 except ImportError:  # So RTD would build
     pass
-try:
-    from stsci.tools import teal
-except:
-    teal = None
 
 __taskname__ = "acsccd"
 __version__ = "2.0"

--- a/acstools/acscte.py
+++ b/acstools/acscte.py
@@ -32,12 +32,6 @@ In Pyraf::
 import os
 import subprocess
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-except ImportError:  # So RTD would build
-    pass
-
 __taskname__ = "acscte"
 __version__ = "1.0"
 __vdate__ = "13-Aug-2013"
@@ -82,6 +76,8 @@ def acscte(input, exec_path='', time_stamps=False, verbose=False, quiet=False,
         one CPU.
 
     """
+    from stsci.tools import parseinput  # Optional package dependency
+
     if exec_path:
         if not os.path.exists(exec_path):
             raise OSError('Executable not found: ' + exec_path)

--- a/acstools/acscte.py
+++ b/acstools/acscte.py
@@ -37,10 +37,6 @@ try:
     from stsci.tools import parseinput
 except ImportError:  # So RTD would build
     pass
-try:
-    from stsci.tools import teal
-except:
-    teal = None
 
 __taskname__ = "acscte"
 __version__ = "1.0"

--- a/acstools/acsrej.py
+++ b/acstools/acsrej.py
@@ -31,10 +31,6 @@ try:
     from stsci.tools import parseinput
 except ImportError:  # So RTD would build
     pass
-try:
-    from stsci.tools import teal
-except:
-    teal = None
 
 __taskname__ = "acsrej"
 __version__ = "1.0"

--- a/acstools/acsrej.py
+++ b/acstools/acsrej.py
@@ -26,12 +26,6 @@ In Pyraf::
 import os
 import subprocess
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-except ImportError:  # So RTD would build
-    pass
-
 __taskname__ = "acsrej"
 __version__ = "1.0"
 __vdate__ = "18-Dec-2012"
@@ -119,6 +113,8 @@ def acsrej(input, output, exec_path='', time_stamps=False, verbose=False,
         This is used for BIAS images.
 
     """
+    from stsci.tools import parseinput  # Optional package dependency
+
     if exec_path:
         if not os.path.exists(exec_path):
             raise OSError('Executable not found: ' + exec_path)

--- a/acstools/acssum.py
+++ b/acstools/acssum.py
@@ -26,12 +26,6 @@ In Pyraf::
 import os
 import subprocess
 
-# STSCI
-try:
-    from stsci.tools import parseinput
-except ImportError:  # So RTD would build
-    pass
-
 __taskname__ = "acssum"
 __version__ = "1.0"
 __vdate__ = "18-Dec-2012"
@@ -73,6 +67,8 @@ def acssum(input, output, exec_path='', time_stamps=False, verbose=False,
         Set to True for quiet output.
 
     """
+    from stsci.tools import parseinput  # Optional package dependency
+
     if exec_path:
         if not os.path.exists(exec_path):
             raise OSError('Executable not found: ' + exec_path)

--- a/acstools/acssum.py
+++ b/acstools/acssum.py
@@ -31,10 +31,6 @@ try:
     from stsci.tools import parseinput
 except ImportError:  # So RTD would build
     pass
-try:
-    from stsci.tools import teal
-except:
-    teal = None
 
 __taskname__ = "acssum"
 __version__ = "1.0"

--- a/acstools/satdet.py
+++ b/acstools/satdet.py
@@ -143,11 +143,23 @@ from astropy.io import fits
 #from astropy.stats import biweight_location
 from astropy.stats import biweight_midvariance, sigma_clipped_stats
 from astropy.utils.exceptions import AstropyUserWarning
-from scipy import stats
-from skimage import transform
-from skimage import morphology as morph
-from skimage import exposure
-from skimage.feature import canny
+
+# OPTIONAL
+try:
+    import skimage
+    from astropy.utils.introspection import minversion
+    from scipy import stats
+    from skimage import transform
+    from skimage import morphology as morph
+    from skimage import exposure
+    from skimage.feature import canny
+except ImportError:
+    HAS_OPDEP = False
+else:
+    if minversion(skimage, '0.11'):
+        HAS_OPDEP = True
+    else:
+        HAS_OPDEP = False
 
 try:
     import matplotlib.pyplot as plt
@@ -572,6 +584,9 @@ def make_mask(filename, ext, trail_coords, sublen=75, subwidth=200, order=3,
 
     Raises
     ------
+    ImportError
+        Missing scipy or skimage>=0.11 packages.
+
     IndexError
         Invalid subarray indices.
 
@@ -580,6 +595,9 @@ def make_mask(filename, ext, trail_coords, sublen=75, subwidth=200, order=3,
         trail profile not found.
 
     """
+    if not HAS_OPDEP:
+        raise ImportError('Missing scipy or skimage>=0.11 packages')
+
     if verbose:
         t_beg = time.time()
 
@@ -1011,7 +1029,15 @@ def detsat(searchpattern, chips=[1, 4], n_processes=4, sigma=2.0,
         Dictionary mapping ``(filename, ext)`` to the error message explaining
         why processing failed.
 
+    Raises
+    ------
+    ImportError
+        Missing scipy or skimage>=0.11 packages.
+
     """
+    if not HAS_OPDEP:
+        raise ImportError('Missing scipy or skimage>=0.11 packages')
+
     if verbose:
         t_beg = time.time()
 

--- a/doc/rtd-pip-requirements
+++ b/doc/rtd-pip-requirements
@@ -1,6 +1,2 @@
 numpy>=1.11
-matplotlib
-astropy-helpers
 astropy
-scipy
-scikit-image>=0.11

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,8 @@ setup(
     package_data={PACKAGENAME: ['pars/*']},
     entry_points=entry_points,
     install_requires = [
-        'astropy>=1.0',
-        'numpy',
-        'scikit-image>=0.11',
-        'scipy',
-        'stsci.imagestats',
-        'stsci.tools',
+        'astropy>=1.1',
+        'numpy'
     ],
     use_2to3=False,
     zip_safe=False


### PR DESCRIPTION
Fixes #9.

@jhunkeler , looks much cleaner now:
```
.../lib/python2.7/site-packages/setuptools-23.0.0-py2.7.egg/setuptools/dist.py:294:
UserWarning: The version specified ('714bc73b') is an invalid version,
this may not work as expected with newer versions of setuptools, pip, and PyPI.
Please see PEP 440 for more details.
running install
running bdist_egg
running egg_info
creating acstools.egg-info
writing requirements to acstools.egg-info/requires.txt
writing acstools.egg-info/PKG-INFO
writing top-level names to acstools.egg-info/top_level.txt
writing dependency_links to acstools.egg-info/dependency_links.txt
writing entry points to acstools.egg-info/entry_points.txt
writing manifest file 'acstools.egg-info/SOURCES.txt'
reading manifest file 'acstools.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*' under directory 'scripts'
no previously-included directories found matching 'build'
no previously-included directories found matching 'doc/build'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '*.o' found anywhere in distribution
writing manifest file 'acstools.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/acstools
copying acstools/__init__.py -> build/lib/acstools
copying acstools/acs2d.py -> build/lib/acstools
copying acstools/acs_destripe.py -> build/lib/acstools
copying acstools/acs_destripe_plus.py -> build/lib/acstools
copying acstools/acsccd.py -> build/lib/acstools
copying acstools/acscte.py -> build/lib/acstools
copying acstools/acsrej.py -> build/lib/acstools
copying acstools/acssum.py -> build/lib/acstools
copying acstools/calacs.py -> build/lib/acstools
copying acstools/satdet.py -> build/lib/acstools
copying acstools/version.py -> build/lib/acstools
creating build/lib/acstools/pars
copying acstools/pars/acs2d.cfg -> build/lib/acstools/pars
copying acstools/pars/acs2d.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acs_destripe.cfg -> build/lib/acstools/pars
copying acstools/pars/acs_destripe.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acs_destripe_plus.cfg -> build/lib/acstools/pars
copying acstools/pars/acs_destripe_plus.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acsccd.cfg -> build/lib/acstools/pars
copying acstools/pars/acsccd.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acscte.cfg -> build/lib/acstools/pars
copying acstools/pars/acscte.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acsrej.cfg -> build/lib/acstools/pars
copying acstools/pars/acsrej.cfgspc -> build/lib/acstools/pars
copying acstools/pars/acssum.cfg -> build/lib/acstools/pars
copying acstools/pars/acssum.cfgspc -> build/lib/acstools/pars
copying acstools/pars/calacs.cfg -> build/lib/acstools/pars
copying acstools/pars/calacs.cfgspc -> build/lib/acstools/pars
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/__init__.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acs2d.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acs_destripe.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acs_destripe_plus.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acsccd.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acscte.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acsrej.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/acssum.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/calacs.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/satdet.py -> build/bdist.linux-x86_64/egg/acstools
copying build/lib/acstools/version.py -> build/bdist.linux-x86_64/egg/acstools
creating build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs2d.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs2d.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs_destripe.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs_destripe.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs_destripe_plus.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acs_destripe_plus.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acsccd.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acsccd.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acscte.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acscte.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acsrej.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acsrej.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acssum.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/acssum.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/calacs.cfg -> build/bdist.linux-x86_64/egg/acstools/pars
copying build/lib/acstools/pars/calacs.cfgspc -> build/bdist.linux-x86_64/egg/acstools/pars
byte-compiling build/bdist.linux-x86_64/egg/acstools/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acs2d.py to acs2d.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acs_destripe.py to acs_destripe.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acs_destripe_plus.py to acs_destripe_plus.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acsccd.py to acsccd.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acscte.py to acscte.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acsrej.py to acsrej.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/acssum.py to acssum.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/calacs.py to calacs.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/satdet.py to satdet.pyc
byte-compiling build/bdist.linux-x86_64/egg/acstools/version.py to version.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/entry_points.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/not-zip-safe -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying acstools.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
creating dist
creating 'dist/acstools-714bc73b-py2.7.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing acstools-714bc73b-py2.7.egg
creating .../lib/python2.7/site-packages/acstools-714bc73b-py2.7.egg
Extracting acstools-714bc73b-py2.7.egg to .../lib/python2.7/site-packages
Adding acstools 714bc73b to easy-install.pth file
Installing acs_destripe script to .../bin
Installing acs_destripe_plus script to .../bin

Installed .../lib/python2.7/site-packages/acstools-714bc73b-py2.7.egg
Processing dependencies for acstools===714bc73b
Searching for numpy==1.11.1
Best match: numpy 1.11.1
Adding numpy 1.11.1 to easy-install.pth file

Using .../lib/python2.7/site-packages
Searching for astropy==1.2.1
Best match: astropy 1.2.1
Adding astropy 1.2.1 to easy-install.pth file
Installing fitsinfo script to .../bin
Installing fitsheader script to .../bin
Installing fits2bitmap script to .../bin
Installing fitsdiff script to .../bin
Installing fitscheck script to .../bin
Installing volint script to .../bin
Installing wcslint script to .../bin
Installing samp_hub script to .../bin

Using .../lib/python2.7/site-packages
Finished processing dependencies for acstools===714bc73b
```