### PR TITLE
[WIP] Prototype to new way of doing regression test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include LICENSE.txt
 
 include setup.cfg
+include tox.ini
 
 include RELIC-INFO
 

--- a/acstools/conftest.py
+++ b/acstools/conftest.py
@@ -1,0 +1,18 @@
+"""Custom ``pytest`` configurations."""
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--remote-data", action="store_true",
+                     help="Use remote data.")
+
+
+def pytest_configure(config):
+    config.getini('markers').append(
+        'remote_data: Run tests that require data from remote servers')
+
+
+def pytest_runtest_setup(item):
+    if ('remote_data' in item.keywords and
+            not item.config.getvalue("remote_data")):
+        pytest.skip("need --remote-data option to run")

--- a/acstools/tests/__init__.py
+++ b/acstools/tests/__init__.py
@@ -1,5 +1,1 @@
 """Unit tests for ACSTOOLS."""
-
-# Currently, tests are on a different system due to large data files being
-# used. In the future, if there are tests that can be added to the package,
-# they should go in this directory.

--- a/acstools/tests/helpers.py
+++ b/acstools/tests/helpers.py
@@ -1,0 +1,19 @@
+import subprocess
+import pytest
+
+# Check for external executables
+
+CALACS = 'calacs.e'
+
+try:
+    subprocess.check_call(['which', CALACS])
+except:
+    HAS_CALACS = False
+else:
+    HAS_CALACS = True
+
+# pytest marker to mark tests which get data from the web
+remote_data = pytest.mark.remote_data
+
+# pytest marker to mark tests that use CALACS
+use_calacs = pytest.mark.skipif(not HAS_CALACS, reason='no CALACS')

--- a/acstools/tests/test_wfc_asn1.py
+++ b/acstools/tests/test_wfc_asn1.py
@@ -1,0 +1,25 @@
+"""CALACS: WFC ASN Set Full-frame Pre-SM4
+
+Process a WFC dataset using CR-SPLIT=2 with all standard calibration steps
+turned on.
+
+"""
+from __future__ import absolute_import, division, print_function
+
+from .helpers import remote_data, use_calacs
+
+
+@remote_data
+@use_calacs
+def test_wfc_asn_fullframe_presm4():
+    pass
+
+
+@remote_data
+def test1():
+    pass
+
+
+@use_calacs
+def test2():
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,7 @@ acs_destripe_plus = acstools.acs_destripe_plus:main
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
-universal=1
+universal = 1
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,15 @@ setup(
     license=LICENSE,
     url=URL,
     classifiers=CLASSIFIERS,
-    packages=[PACKAGENAME],
-    package_dir={PACKAGENAME: PACKAGENAME},
+    packages=[PACKAGENAME, PACKAGENAME + '.tests'],
     package_data={PACKAGENAME: ['pars/*']},
     entry_points=entry_points,
     install_requires = [
         'astropy>=1.1',
         'numpy'
     ],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     use_2to3=False,
     zip_safe=False
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = "build" "doc[\/]_build" "relic"


### PR DESCRIPTION
**DO NOT MERGE**

Here is one way I have envisioned on how to modernize CALACS regression tests. Running the following command in the top-level source directory...

This one automatically skips the tests marked as needing remote data:

```
> py.test acstools 
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: .../acstools/fork, inifile: tox.ini
collected 3 items 

acstools/tests/test_wfc_asn1.py ss.

===================== 1 passed, 2 skipped in 0.08 seconds ======================
```

This one runs tests needing remote data but not CALACS (when `calacs.e` is missing):

```
> py.test acstools --remote-data
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: .../acstools/fork, inifile: tox.ini
collected 3 items 

acstools/tests/test_wfc_asn1.py s.s

===================== 1 passed, 2 skipped in 0.07 seconds ======================
```

This one runs all the tests (when `calacs.e` is installed):

```
> py.test acstools --remote-data
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: .../acstools/fork, inifile: tox.ini
collected 3 items 

acstools/tests/test_wfc_asn1.py ...

=========================== 3 passed in 0.06 seconds ===========================
```

Of course, those are just dummy tests. Because this PR is on how to run them, hence the test contents are irrelevant. Using `pytest`, each test can be easily set up to grab files from remote location and remove them on exit, etc.

I still cannot get `python setup.py test` command to work properly (note that I use `py.test` directly above) without having to rely on Astropy test runner (hence turning `acstools` into an affiliated package). But if relying on `astropy` or `astropy_helpers` submodule is not a problem, it is easier to just use what they already support.

Thoughts?

@sosey @jhunkeler 
