### PR TITLE
Fix TypeError in Numpy 1.12 indexing

### DIFF
--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -337,6 +337,10 @@ def find_line(scihdu, refhdu):
         x0 = xzero
         y0 = yzero
 
+    # Ensure integer index
+    x0 = int(x0)
+    y0 = int(y0)
+
     return same_size, rx, ry, x0, y0
 
 


### PR DESCRIPTION
It was done as part of #19 but that one was not merged, so this went through the crack.