### PR TITLE
Compatibility with Astropy 2.0

### DIFF
--- a/acstools/acs_destripe.py
+++ b/acstools/acs_destripe.py
@@ -55,8 +55,10 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 # THIRD-PARTY
+import astropy
 import numpy as np
 from astropy.io import fits
+from astropy.utils.introspection import minversion
 
 # LOCAL
 from .utils_calib import extract_dark, extract_flash, extract_flatfield
@@ -189,7 +191,10 @@ class StripeArray(object):
             self.hdulist['err', 1].data = self.err.copy()
 
         # Write the output
-        self.hdulist.writeto(output, clobber=clobber)
+        if minversion(astropy, '1.3'):
+            self.hdulist.writeto(output, overwrite=clobber)
+        else:
+            self.hdulist.writeto(output, clobber=clobber)
 
     def close(self):
         """Close open file(s)."""


### PR DESCRIPTION
Replace FITS "clobber" keyword with "overwrite". The new keyword was introduced in Astropy 1.3. The old one deprecated in 2.0 and will be removed in 3.0. Do not confuse this with the local "clobber" keyword in "acs_destripe", as there is no plans to deprecate *that*.

Note for future: When our minimum Astropy requirement has gone beyond 1.3 (not sure who decides that), "clobber" part of this logic can be removed altogether.