### PR TITLE
Added function to check for weird custom subarrays

### DIFF
--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -522,7 +522,10 @@ def is_weird_subarray(filename):
         x1 = x0 + nx
         y1 = y0 + ny
 
-        # Assume rx and ry are always 1.
+        # TODO: Document why binned data is not a concern.
+        if rx != 1 or ry != 1:
+            raise NotImplementedError('Binned data check is not supported')
+
         if ((not same_size) and
                 (x0 < 0 or y0 < 0 or x1 > max_x or y1 > max_y)):
             oscntab = prihdr['OSCNTAB'].replace('jref$', os.environ['jref'])

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -506,9 +506,10 @@ def is_weird_subarray(filename):
         prihdr = pf[0].header
 
         # We won't use OSCNTAB, so don't worry about it.
-        if (prihdr['DETECTOR'] not in ('WFC', 'HRC') or
-                prihdr['BLEVCORR'] != 'PERFORM' or
-                prihdr['DARKCORR'] != 'PERFORM'):
+        if (prihdr['DETECTOR'].strip().upper() not in ('WFC', 'HRC') or
+                prihdr['CTEIMAGE'].strip().upper() == "EPER" or
+                prihdr['BLEVCORR'].strip().upper() != 'PERFORM' or
+                prihdr['DARKCORR'].strip().upper() != 'PERFORM'):
             return is_weird
 
         scihdr = pf[1].header
@@ -531,12 +532,14 @@ def is_weird_subarray(filename):
             oscntab = prihdr['OSCNTAB'].replace('jref$', os.environ['jref'])
             tab = Table.read(oscntab)
 
-            ccdamp = prihdr['CCDAMP']
+            ccdamp = prihdr['CCDAMP'].strip().upper()
             ccdchip = scihdr['CCDCHIP']
 
             # CCDAMP column might have trailing whitespace.
-            rows = tab[((tab['CCDAMP'] == ccdamp) |
-                        (tab['CCDAMP'] == '{:<4s}'.format(ccdamp))) &
+            # https://github.com/astropy/astropy/issues/2608
+            ccdamp_col = np.char.rstrip(tab['CCDAMP'])
+
+            rows = tab[(ccdamp_col == ccdamp) &
                        (tab['CCDCHIP'] == ccdchip) &
                        (tab['NX'] == nx) &
                        (tab['NY'] == ny)]

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -507,7 +507,8 @@ def is_weird_subarray(filename):
 
         # We won't use OSCNTAB, so don't worry about it.
         if (prihdr['DETECTOR'] not in ('WFC', 'HRC') or
-                prihdr['BLEVCORR'] != 'PERFORM'):
+                prihdr['BLEVCORR'] != 'PERFORM' or
+                prihdr['DARKCORR'] != 'PERFORM'):
             return is_weird
 
         scihdr = pf[1].header

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -523,7 +523,7 @@ def is_weird_subarray(filename):
 
         # Assume rx and ry are always 1.
         if ((not same_size) and
-                (x0 < 0 or y0 < 0 or x1 >= max_x or y1 >= max_y)):
+                (x0 < 0 or y0 < 0 or x1 > max_x or y1 > max_y)):
             oscntab = prihdr['OSCNTAB'].replace('jref$', os.environ['jref'])
             tab = Table.read(oscntab)
 


### PR DESCRIPTION
This should more or less sniff out the custom subarrays from the past that cannot get through the pipeline because they have overscan but lack an entry in the their OSCNTAB.