### PR TITLE
Enable CRREJ on acs_destripe_plus products

### DIFF
--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -69,7 +69,7 @@ From command line::
 #           corrections in the "RAW" space) and support for various
 #           statistics modes. See Ticket #1183.
 # 12JAN2016 (v0.4.1) Lim added new subarray modes that are allowed CTE corr.
-# 08NOV2017 (v0.4.2) Lim added capability to produce CRJ/CRC outputs.
+# 27AUG2018 (v0.4.3) Lim added capability to produce CRJ/CRC outputs.
 
 from __future__ import absolute_import, division, print_function
 
@@ -99,8 +99,8 @@ from . import acscte
 from . import acsrej
 
 __taskname__ = 'acs_destripe_plus'
-__version__ = '0.4.2'
-__vdate__ = '31-May-2018'
+__version__ = '0.4.3'
+__vdate__ = '27-Aug-2018'
 __author__ = 'Leonardo Ubeda, Sara Ogaz (ACS Team), STScI'
 __all__ = ['destripe_plus', 'crrej_plus']
 

--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -514,7 +514,7 @@ def destripe_plus(inputfile, suffix='strp', stat='pmode1', maxiter=15,
     LOG.info(info_str)
 
 
-def crrej_plus(filelist, outroot, verbose=True):
+def crrej_plus(filelist, outroot, keep_intermediate_files=False, verbose=True):
     """
     Perform CRREJ and ACS2D on given BLV_TMP or BLC_TMP files.
     The purpose of this is primarily for combining destriped
@@ -539,6 +539,10 @@ def crrej_plus(filelist, outroot, verbose=True):
         ``<rootname>_crj.fits`` (for BLV inputs) or
         ``<rootname>_crc.fits`` (for BLC inputs).
 
+    keep_intermediate_files : bool
+        Keep de-striped CRJ_TMP or CRC_TMP around after CRREJ,
+        if needed. Default = False.
+
     verbose : bool
         Print informational messages. Default = True.
 
@@ -554,9 +558,11 @@ def crrej_plus(filelist, outroot, verbose=True):
     >>> acs_destripe_plus.destripe_plus(..., keep_intermediate_files=True)
     >>> rootname = 'j12345678'
     >>> blv_files = glob.glob('*_blv_tmp.fits')
-    >>> acs_destripe_plus.crrej_plus(blv_files, rootname)
+    >>> acs_destripe_plus.crrej_plus(
+    ...     blv_files, rootname, keep_intermediate_files=True)
     >>> blc_files = glob.glob('*_blc_tmp.fits')
-    >>> acs_destripe_plus.crrej_plus(blc_files, rootname)
+    >>> acs_destripe_plus.crrej_plus(
+    ...     blc_files, rootname, keep_intermediate_files=True)
 
     """
     is_blv = np.all(['blv_tmp.fits' in f for f in filelist])
@@ -575,7 +581,7 @@ def crrej_plus(filelist, outroot, verbose=True):
     acs2d.acs2d(tmpname, verbose=verbose)  # crx_tmp -> crx
 
     # Delete intermediate file
-    if os.path.isfile(tmpname):
+    if not keep_intermediate_files and os.path.isfile(tmpname):
         os.remove(tmpname)
 
 

--- a/acstools/pars/acs_destripe.cfg
+++ b/acstools/pars/acs_destripe.cfg
@@ -14,4 +14,3 @@ rpt_clean = 0
 atol = 0.01
 clobber = False
 verbose = True
-[_RULES_]

--- a/acstools/pars/acs_destripe_plus.cfg
+++ b/acstools/pars/acs_destripe_plus.cfg
@@ -13,6 +13,6 @@ dqbits = ""
 rpt_clean = 0
 atol = 0.01
 cte_correct = True
+keep_intermediate_files = False
 clobber = False
 verbose = True
-[_RULES_]

--- a/acstools/pars/acs_destripe_plus.cfgspc
+++ b/acstools/pars/acs_destripe_plus.cfgspc
@@ -13,5 +13,6 @@ dqbits = string_kw(default="", comment="Integer mask bit values considered good 
 rpt_clean = integer_kw(default=0, comment= "Number of de-stripe cleanings to *repeat*")
 atol = float_or_none_kw(default=0.01, comment= "Absolute tolerance to stop *repeated* bias stripe cleanings")
 cte_correct = boolean_kw(default=True, comment="Perform CTE correction")
+keep_intermediate_files = boolean_kw(default=False, comment="Keep intermediate BLV_TMP and BLC_TMP files")
 clobber = boolean_kw(default=False, comment="Delete and replace previous products?")
 verbose = boolean_kw(default=True, comment= "Verbose")


### PR DESCRIPTION
Fix #35 -- Enable CRREJ on `acs_destripe_plus` products. Needed to add a new function named `crrej_plus()` due to the recursive nature of `acs_destripe_plus()`, which was meant to process individual exposures, not combine them.

Fix #66 

Bonus: Removed unexpected `_RULES_` section warning when using TEAL interface. Some minor PEP 8 clean-ups on the module.

c/c @jryon , @nmiles2718 , and @tddesjardins