### PR TITLE
Replace help email with website

### DIFF
--- a/doc/source/calacs_hstcal.rst
+++ b/doc/source/calacs_hstcal.rst
@@ -5,7 +5,7 @@ calacs.e (HSTCAL)
 A detailed description of this new and improved CALACS is available in
 `ACS Data Handbook v7.0 or later <http://www.stsci.edu/hst/acs/documents/handbooks/currentDHB/>`_.
 If you have questions not answered in the documentation, please contact
-STScI Help Desk (``help[at]stsci.edu``).
+`STScI Help Desk <https://hsthelp.stsci.edu>`_.
 
 
 Running CALACS


### PR DESCRIPTION
Fix #59 

There is also the `author_email` in `setup.cfg` but it was decided that that one is out of scope.