### PR TITLE
Enable concurrent build configurations

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -15,26 +15,20 @@ bc.conda_packages = ['python=3.6',
                      'matplotlib',
                      'scipy',
                      'scikit-image',
-                     'stsci.tools']
-bc.build_cmds = ["pip install ci-watson",
-                 "python setup.py install"]
+                     'stsci.tools',
+                     'ci-watson']
+bc.build_cmds = ["python setup.py install"]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6
 
-// TODO: Enable this when boyle can support parallel runs.
-//       https://github.com/spacetelescope/calcos/issues/41
 // Astropy dev and Python 3.7
-//bc1 = utils.copy(bc)
-//bc1.name = "dev"
-//bc1.conda_packages[0] = "python=3.7"
-//bc1.build_cmds = ["pip install ci-watson",
-//                  "pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
-//                 "python setup.py install"]
+bc1 = utils.copy(bc)
+bc1.name = "dev"
+bc1.conda_packages[0] = "python=3.7"
+bc1.build_cmds = ["pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps",
+                 "python setup.py install"]
 
 // Iterate over configurations that define the (distibuted) build matrix.
-// Spawn a host of the given nodetype for each combination and run in parallel.
-// TODO: Enable this when boyle can support parallel runs.
-//       https://github.com/spacetelescope/calcos/issues/41
-//utils.run([bc, bc1])
-utils.run([bc])
+// Spawn a host (or workdir) for each combination and run in parallel.
+utils.run([bc, bc1])


### PR DESCRIPTION
...and pull ci-watson package from Astroconda instead of PyPI to consolidate dependencies.

Facilitated by spacetelescope/jenkins_shared_ci_utils#17

EDIT: Fix #71