### PR TITLE
MNT: Remove PY2 support

### DIFF
--- a/acstools/__init__.py
+++ b/acstools/__init__.py
@@ -6,8 +6,6 @@ Utility and library functions used by these tasks are also included in this
 module.
 
 """
-from __future__ import absolute_import, print_function
-
 try:
     from .version import *
 except ImportError:

--- a/acstools/acs2d.py
+++ b/acstools/acs2d.py
@@ -5,7 +5,7 @@ Use this function to facilitate batch runs of ACS2D, or for the TEAL interface.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acs2d
 >>> acs2d.acs2d('*blv_tmp.fits')
@@ -15,11 +15,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acs2d
 >>> teal.teal('acs2d')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acs2d
 
 For help usage use ``exe_args=['--help']``
 
@@ -34,7 +29,8 @@ __vdate__ = "10-Oct-2014"
 __all__ = ['acs2d']
 
 
-def acs2d(input, exec_path='', time_stamps=False, verbose=False, quiet=False, exe_args=None):
+def acs2d(input, exec_path='', time_stamps=False, verbose=False, quiet=False,
+          exe_args=None):
     r"""
     Run the acs2d.e executable as from the shell.
 

--- a/acstools/acs_destripe.py
+++ b/acstools/acs_destripe.py
@@ -22,7 +22,7 @@ For more information, see
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acs_destripe
 >>> acs_destripe.clean('uncorrected_flt.fits', 'csck',
@@ -35,11 +35,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> teal.teal('acs_destripe')
 
-In Pyraf::
-
-    --> import acstools
-    --> teal acs_destripe
-
 From command line::
 
     % acs_destripe [-h] [--stat STAT] [--lower [LOWER]] [--upper [UPPER]]
@@ -49,15 +44,11 @@ From command line::
                    input suffix [maxiter] [sigrej]
 
 """
-from __future__ import absolute_import, division, print_function
-
 # STDLIB
 import logging
 
 # THIRD-PARTY
-import astropy
 import numpy as np
-from astropy.utils.introspection import minversion
 
 try:
     # This supports PIXVALUE
@@ -197,10 +188,7 @@ class StripeArray(object):
             self.hdulist['err', 1].data = self.err.copy()
 
         # Write the output
-        if minversion(astropy, '1.3'):
-            self.hdulist.writeto(output, overwrite=clobber)
-        else:
-            self.hdulist.writeto(output, clobber=clobber)
+        self.hdulist.writeto(output, overwrite=clobber)
 
     def close(self):
         """Close open file(s)."""

--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -18,7 +18,7 @@ For more information, see
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acs_destripe_plus
 >>> acs_destripe_plus.destripe_plus(
@@ -31,11 +31,6 @@ In Python with TEAL:
 >>> from acstools import acs_destripe_plus
 >>> from stsci.tools import teal
 >>> teal.teal('acs_destripe_plus')
-
-In Pyraf::
-
-    --> import acstools
-    --> teal acs_destripe_plus
 
 From command line::
 
@@ -68,8 +63,6 @@ From command line::
 #           corrections in the "RAW" space) and support for various
 #           statistics modes. See Ticket #1183.
 # 12JAN2016 (v0.4.1) Lim added new subarray modes that are allowed CTE corr.
-
-from __future__ import absolute_import, division, print_function
 
 # STDLIB
 import logging

--- a/acstools/acsccd.py
+++ b/acstools/acsccd.py
@@ -9,7 +9,7 @@ Use this function to facilitate batch runs of ACSCCD, or for the TEAL interface.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acsccd
 >>> acsccd.acsccd('*raw.fits')
@@ -19,11 +19,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acsccd
 >>> teal.teal('acsccd')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acsccd
 
 For help usage use ``exe_args=['--help']``
 
@@ -49,7 +44,8 @@ __all__ = ['acsccd']
 #     If all False, will set all but ATODCORR to PERFORM.
 #     If any is True, will set that to PERFORM and the rest to OMIT.
 #
-def acsccd(input, exec_path='', time_stamps=False, verbose=False, quiet=False, exe_args=None):
+def acsccd(input, exec_path='', time_stamps=False, verbose=False, quiet=False,
+           exe_args=None):
     r"""
     Run the acsccd.e executable as from the shell.
 

--- a/acstools/acscte.py
+++ b/acstools/acscte.py
@@ -11,7 +11,7 @@ for more details.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acscte
 >>> acscte.acscte('*blv_tmp.fits')
@@ -21,11 +21,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acscte
 >>> teal.teal('acscte')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acscte
 
 For help usage use ``exe_args=['--help']``
 

--- a/acstools/acscteforwardmodel.py
+++ b/acstools/acscteforwardmodel.py
@@ -16,7 +16,7 @@ For guidance on running the CTE forward model, see the Jupyter notebook
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acscteforwardmodel
 >>> acscteforwardmodel.acscteforwardmodel('*blc_tmp.fits')
@@ -26,11 +26,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acscteforwardmodel
 >>> teal.teal('acscteforwardmodel')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acscteforwardmodel
 
 For help usage use ``exe_args=['--help']``
 

--- a/acstools/acsrej.py
+++ b/acstools/acsrej.py
@@ -6,7 +6,7 @@ TEAL interface.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acsrej
 >>> acsrej.acsrej('*flt.fits', 'combined_image.fits')
@@ -16,11 +16,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acsrej
 >>> teal.teal('acsrej')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acsrej
 
 For help usage use ``exe_args=['--help']``
 

--- a/acstools/acssum.py
+++ b/acstools/acssum.py
@@ -5,7 +5,7 @@ Use this function to facilitate batch runs of ACSSUM, or for the TEAL interface.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import acssum
 >>> acssum.acssum('*flt.fits', 'combined_image.fits')
@@ -15,11 +15,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import acssum
 >>> teal.teal('acssum')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar acssum
 
 For help usage use ``exe_args=['--help']``
 

--- a/acstools/acszpt.py
+++ b/acstools/acszpt.py
@@ -77,11 +77,10 @@ Retrieve the zeropoint information for the F435W filter for WFC at multiple date
 >>> type(queries[0].zpt_table['PHOTFLAM'])
 astropy.units.quantity.Quantity
 """
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError
-
 import datetime as dt
 import logging
+from urllib.request import urlopen
+from urllib.error import URLError
 
 import astropy.units as u
 from astropy.table import QTable

--- a/acstools/calacs.py
+++ b/acstools/calacs.py
@@ -5,7 +5,7 @@ Use this function to facilitate batch runs of CALACS, or for the TEAL interface.
 Examples
 --------
 
-In Python without TEAL:
+In Python without TEAL (recommended):
 
 >>> from acstools import calacs
 >>> calacs.calacs(filename)
@@ -15,11 +15,6 @@ In Python with TEAL:
 >>> from stsci.tools import teal
 >>> from acstools import calacs
 >>> teal.teal('calacs')
-
-In Pyraf::
-
-    --> import acstools
-    --> epar calacs
 
 For help usage use ``exe_args=['--help']``
 
@@ -31,7 +26,8 @@ __all__ = ['calacs']
 
 
 def calacs(input_file, exec_path=None, time_stamps=False, temp_files=False,
-           verbose=False, debug=False, quiet=False, single_core=False, exe_args=None):
+           verbose=False, debug=False, quiet=False, single_core=False,
+           exe_args=None):
     """
     Run the calacs.e executable as from the shell.
 

--- a/acstools/satdet.py
+++ b/acstools/satdet.py
@@ -16,7 +16,7 @@ within an ACS/WFC image as published in
 
     Performance is faster when ``plot=False``, where applicable.
 
-    Currently *not* supported in TEAL and PyRAF.
+    Currently *not* supported in TEAL.
 
 Examples
 --------
@@ -127,9 +127,6 @@ jc8m10syq_flc.fits[6] updated
 #    Dec 07, 2015 - PLL - Minor changes based on feedback from DMB.
 #    May 24, 2016 - SMO - Minor import changes to skimage
 #
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from six.moves import map
 
 # STDLIB
 import glob
@@ -140,7 +137,6 @@ from functools import partial
 from multiprocessing import Process, Queue
 
 # THIRD PARTY
-import astropy
 import numpy as np
 from astropy.io import fits
 # from astropy.stats import biweight_location
@@ -149,11 +145,8 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.introspection import minversion
 
 # See https://github.com/astropy/astropy/issues/6364
-if minversion(astropy, '2.0'):
-    from astropy.stats import biweight_scale
-    biweight_midvariance = partial(biweight_scale, modify_sample_size=False)
-else:
-    from astropy.stats import biweight_midvariance
+from astropy.stats import biweight_scale
+biweight_midvariance = partial(biweight_scale, modify_sample_size=False)
 
 # OPTIONAL
 try:
@@ -183,8 +176,6 @@ __vdate__ = '11-Jul-2017'
 __author__ = 'David Borncamp, Pey Lian Lim'
 __all__ = ['detsat', 'make_mask', 'update_dq']
 
-
-# ########################### from satdet.py ################################ #
 
 def _detsat_one(filename, ext, sigma=2.0, low_thresh=0.1, h_thresh=0.5,
                 small_edge=60, line_len=200, line_gap=75,

--- a/acstools/tests/helpers.py
+++ b/acstools/tests/helpers.py
@@ -1,7 +1,6 @@
 """ACSTOOLS regression test helpers."""
 
 import os
-import sys
 
 import pytest
 from ci_watson.artifactory_helpers import get_bigdata
@@ -96,11 +95,6 @@ class BaseACSTOOLS:
             environment in which input and truth files reside.
 
         """
-        # Since ACSTOOLS still runs in PY2, need to check here because
-        # tests can only run in PY3.
-        if sys.version_info < (3, ):
-            raise SystemError('tests can only run in Python 3')
-
         self.env = envopt
 
     def get_input_file(self, filename):

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -1,5 +1,4 @@
 """General utilities for ACS calibration adapted from HSTCAL."""
-from __future__ import absolute_import, division, print_function
 
 # STDLIB
 import os

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,10 @@ Software tools for
     Standalone CTE correction (``PixCteCorr``) is no longer supported.
     Please use :ref:`acstools-doc-acscte`.
 
+.. note::
+
+    Python 2 is no longer supported. Please use Python 3.5 or later.
+
 Contents:
 
 .. toctree::

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ classifier =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
@@ -18,12 +17,6 @@ classifier =
 [entry_points]
 acs_destripe = acstools.acs_destripe:main
 acs_destripe_plus = acstools.acs_destripe_plus:main
-
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1
 
 [tool:pytest]
 minversion = 3.0

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,7 @@ if not pkgutil.find_loader('relic'):
 import relic.release
 
 # Get some values from the setup.cfg
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from configparser import ConfigParser
 conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
@@ -64,13 +61,12 @@ setup(
     package_dir={PACKAGENAME: PACKAGENAME},
     package_data={PACKAGENAME: ['pars/*']},
     entry_points=entry_points,
+    python_requires='>=3.5',
     install_requires=[
-        'astropy>=1.1',
+        'astropy>=2',
         'numpy',
-        'beautifulsoup4',
-        'six'
+        'beautifulsoup4'
     ],
     tests_require=['pytest'],
-    use_2to3=False,
     zip_safe=False
 )


### PR DESCRIPTION
Fix #65 . Also removed mention of PyRAF since it is only distributed in Python 2. This should be the last PR needed before the next release.