### PR TITLE
TST: Fix satdet failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,9 @@ bc1.conda_packages = ['python=3.6',
                       'numpy',
                       'matplotlib',
                       'scipy',
-                      'scikit-image',
-                      'stsci.tools']
-bc1.build_cmds = ["pip install ci-watson",
+                      'stsci.tools',
+                      'ci-watson']
+bc1.build_cmds = ["pip install scikit-image",
                   "python setup.py install"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -19,10 +19,10 @@ bc.conda_packages = ['python=3.6',
                      'numpy',
                      'matplotlib',
                      'scipy',
-                     'scikit-image',
                      'stsci.tools',
                      'ci-watson']
-bc.build_cmds = ["python setup.py install"]
+bc.build_cmds = ["pip install scikit-image",
+                 "python setup.py install"]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6


### PR DESCRIPTION
Fix #84 

`scikit-image` in `defaults` conda channel is incompatible with Numpy 1.16. So to get the updated version of `scikit-image` that is compatible, we have to `pip install` it instead.