### PR TITLE
Obtain ci-watson using pip rather than conda.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,8 @@ bc1.conda_packages = ['python=3.6',
                       'numpy',
                       'matplotlib',
                       'scipy',
-                      'stsci.tools',
-                      'ci-watson']
-bc1.build_cmds = ["pip install scikit-image",
+                      'stsci.tools']
+bc1.build_cmds = ["pip install scikit-image ci-watson",
                   "python setup.py install"]
 bc1.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -19,9 +19,8 @@ bc.conda_packages = ['python=3.6',
                      'numpy',
                      'matplotlib',
                      'scipy',
-                     'stsci.tools',
-                     'ci-watson']
-bc.build_cmds = ["pip install scikit-image",
+                     'stsci.tools']
+bc.build_cmds = ["pip install scikit-image ci-watson",
                  "python setup.py install"]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1

--- a/conftest.py
+++ b/conftest.py
@@ -7,9 +7,6 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 #       but not released yet.
 enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=['socks'])
 
-# Require these pytest plugins to run.
-pytest_plugins = ["pytest_ciwatson"]
-
 
 # For easy inspection on what dependencies were used in test.
 def pytest_report_header(config):


### PR DESCRIPTION
Maintenance of ci-watson as a conda package confers no benefit. Using the package as provided on PyPI is simpler.