### PR TITLE
Standardizes the SM4 MJD date and updates affected modules

### DIFF
--- a/acstools/acs_destripe.py
+++ b/acstools/acs_destripe.py
@@ -52,7 +52,7 @@ except ImportError:
     from astropy.io import fits
 
 # LOCAL
-from .utils_calib import extract_dark, extract_flash, extract_flatfield
+from .utils_calib import extract_dark, extract_flash, extract_flatfield, SM4_MJD
 
 __taskname__ = 'acs_destripe'
 __version__ = '0.8.2'
@@ -72,7 +72,6 @@ __all__ = ['clean']
 #           corrections in the "RAW" space) and support for various
 #           statistics modes. See Ticket #1183.
 
-MJD_SM4 = 54967
 
 logging.basicConfig()
 LOG = logging.getLogger(__taskname__)
@@ -421,7 +420,7 @@ def clean(input, suffix, stat="pmode1", maxiter=15, sigrej=2.0,
 
     for image, maskfile1, maskfile2 in zip(flist, mlist1, mlist2):
         # Skip processing pre-SM4 images
-        if (fits.getval(image, 'EXPSTART') <= MJD_SM4):
+        if (fits.getval(image, 'EXPSTART') <= SM4_MJD):
             LOG.warning(f'{image} is pre-SM4. Skipping...')
             continue
 

--- a/acstools/acs_destripe_plus.py
+++ b/acstools/acs_destripe_plus.py
@@ -81,6 +81,7 @@ from . import acs_destripe
 from . import acs2d
 from . import acsccd
 from . import acscte
+from .utils_calib import SM4_MJD
 
 __taskname__ = 'acs_destripe_plus'
 __version__ = '0.4.2'
@@ -88,7 +89,6 @@ __vdate__ = '31-May-2018'
 __author__ = 'Leonardo Ubeda, Sara Ogaz (ACS Team), STScI'
 __all__ = ['destripe_plus']
 
-SM4_DATE = Time('2008-01-01')
 SUBARRAY_LIST = [
     'WFC1-2K', 'WFC1-POL0UV', 'WFC1-POL0V', 'WFC1-POL60V',
     'WFC1-POL60UV', 'WFC1-POL120V', 'WFC1-POL120UV', 'WFC1-SMFL',
@@ -377,7 +377,7 @@ def destripe_plus(inputfile, suffix='strp', stat='pmode1', maxiter=15,
     ctecorr = header['PCTECORR']
     aperture = header['APERTURE']
     detector = header['DETECTOR']
-    date_obs = Time(header['DATE-OBS'])
+    date_obs = Time(header['DATE-OBS']).mjd  # Convert to MJD for comparison
 
     # intermediate filenames
     blvtmp_name = inputfile.replace('raw', 'blv_tmp')
@@ -392,7 +392,7 @@ def destripe_plus(inputfile, suffix='strp', stat='pmode1', maxiter=15,
         raise ValueError(f"{inputfile} is not a WFC image, please check the "
                          "'DETECTOR' keyword.")
 
-    if date_obs < SM4_DATE:
+    if date_obs < SM4_MJD:
         raise ValueError(f"{inputfile} is a pre-SM4 image.")
 
     if header['SUBARRAY'] and cte_correct:

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -22,7 +22,7 @@ __all__ = ['extract_dark', 'extract_flash', 'extract_flatfield',
            'check_overscan', 'SM4_MJD']
 
 # The MJD date of the EVA during SM4 to restore ACS/WFC and ACS/HRC.
-# This value is also defined in header file, acs.h, for us by calacs.e in hstcal
+# This value is also defined in header file, acs.h, for use by calacs.e in hstcal
 SM4_MJD = 54967.0
 
 

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -19,9 +19,10 @@ except ImportError:
 __all__ = ['extract_dark', 'extract_flash', 'extract_flatfield',
            'from_irafpath', 'extract_ref', 'find_line', 'get_corner', 'get_lt',
            'from_lt', 'hdr_vals_for_overscan', 'check_oscntab',
-           'check_overscan']
+           'check_overscan', 'SM4_MJD']
 
-# The MJD date of the EVA during SM4 to restore ACS/WFC and ACS/HRC
+# The MJD date of the EVA during SM4 to restore ACS/WFC and ACS/HRC.
+# This value is also defined in header file, acs.h, for us by calacs.e in hstcal
 SM4_MJD = 54967.0
 
 

--- a/acstools/utils_calib.py
+++ b/acstools/utils_calib.py
@@ -21,6 +21,9 @@ __all__ = ['extract_dark', 'extract_flash', 'extract_flatfield',
            'from_lt', 'hdr_vals_for_overscan', 'check_oscntab',
            'check_overscan']
 
+# The MJD date of the EVA during SM4 to restore ACS/WFC and ACS/HRC
+SM4_MJD = 54967.0
+
 
 def extract_dark(prihdr, scihdu):
     """Extract superdark data from ``DARKFILE`` or ``DRKCFILE``.

--- a/doc/source/acs_destripe.rst
+++ b/doc/source/acs_destripe.rst
@@ -10,12 +10,6 @@ ACS Destripe
    :members: clean
 
 
-Global Variables
-----------------
-
-.. autodata:: acstools.acs_destripe.MJD_SM4
-
-
 Version
 -------
 

--- a/doc/source/acs_destripe_plus.rst
+++ b/doc/source/acs_destripe_plus.rst
@@ -13,7 +13,6 @@ ACS Destripe Plus
 Global Variables
 ----------------
 
-.. autodata:: acstools.acs_destripe_plus.SM4_DATE
 .. autodata:: acstools.acs_destripe_plus.SUBARRAY_LIST
 
 


### PR DESCRIPTION
- After conversation with the ACS Team, the agreed upon MJD date for SM4 is 54967. This date corresponds to the EVA for ACS repair during SM4. 


This PR closes #118 
