### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ acs_destripe = acstools.acs_destripe:main
 acs_destripe_plus = acstools.acs_destripe_plus:main
 
 [tool:pytest]
+addopts = --doctest-ignore-import-errors
 minversion = 4.0
 testpaths = "acstools" "doc"
 norecursedirs = build doc/build


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.