### PR TITLE
TST: Fix CI failures

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,6 +95,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
+        pip install git+https://github.com/spacetelescope/ci_watson.git --upgrade --no-deps
         python -m pip install -e .[test,all]
     - name: Test
       run: pytest --remote-data -v

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        pip install git+https://github.com/spacetelescope/ci_watson.git --upgrade --no-deps
         python -m pip install -e .[test,all]
     - name: Test
       run: pytest --remote-data -v

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 6 * * 2'
 
 env:
-  jref: "https://ssb.stsci.edu/cdbs/jref"
+  jref: "https://ssb.stsci.edu/trds_open/jref"
 
 jobs:
   initial_checks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
-  system_packages: true
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,8 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-from pkg_resources import get_distribution
+from importlib import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -53,7 +52,7 @@ copyright = u'2020, STScI'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution('acstools').version
+release = metadata.version('acstools')
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-from importlib import metadata
+from acstools import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -52,7 +52,7 @@ copyright = u'2020, STScI'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = metadata.version('acstools')
+release = __version__
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ astropy_header = true
 xfail_strict = true
 filterwarnings =
   error
+  ignore:numpy\.ndarray size changed:RuntimeWarning
   ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ xfail_strict = true
 filterwarnings =
   error
   ignore:numpy\.ndarray size changed:RuntimeWarning
+  ignore:unclosed file:ResourceWarning
   ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ test =
     ci-watson
 docs =
     sphinx-automodapi
+    sphinx-rtd-theme
 
 [options.package_data]
 acstools = data/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ testpaths = "acstools" "doc"
 norecursedirs = build doc/build
 astropy_header = true
 xfail_strict = true
+filterwarnings =
+  error
+  ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [flake8]
 # Ignoring these for now:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address warnings and remote data failures due to upstream changes. All the deprecation warnings are from upstream packages:

* `astropy`: Fixed in stable version that requires Python 3.8 or newer, so jobs using Python 3.7 won't see that fix.
* `pytest-remotedata`: astropy/pytest-remotedata#58
* `stsci.tools`: spacetelescope/stsci.tools#144