### PR TITLE
Update to the skimage.morphology.remove_small_objects() function in satdet.py.

### DIFF
--- a/acstools/satdet.py
+++ b/acstools/satdet.py
@@ -215,7 +215,7 @@ def _detsat_one(filename, ext, sigma=2.0, low_thresh=0.1, h_thresh=0.5,
 
     # clean up the small objects, will make less noise
     morph.remove_small_objects(edge, min_size=small_edge, connectivity=8,
-                               in_place=True)
+                               out=edge)
 
     # create an array of angles from 0 to 180, exactly 0 will get bad columns
     # but it is unlikely that a satellite will be exactly at 0 degrees, so


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address an error that pops up due to a newer version of scikit-image. The new version has deprecated "in_place" in favor of "out" in the skimage.morphology.remove_small_objects() function. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
