### PR TITLE
BLD: Do not use OpenAstronomy workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Wheel building
 
 on:
   pull_request:
-    # We also want this workflow triggered if the 'Build all wheels'
+    # We also want this workflow triggered if the 'Build wheels'
     # label is added or present when PR is updated
     types:
       - synchronize
@@ -13,9 +13,12 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+# NOTE: Cannot use OpenAstronomy workflow due to
+#       https://github.com/OpenAstronomy/github-actions-workflows/issues/168
 jobs:
   build_and_publish:
     # This job builds the wheels and publishes them to PyPI for all
@@ -25,18 +28,37 @@ jobs:
     permissions:
       contents: none
 
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-
+    runs-on: ubuntu-latest
     if: (github.repository == 'spacetelescope/acstools' && (github.event_name == 'push' ||  contains(github.event.pull_request.labels.*.name, 'Build wheels')))
-    with:
-      env: |
-        jref: "https://ssb.stsci.edu/trds_open/jref"
 
-      # We upload to PyPI for all tag pushes
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'push' }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      test_extras: test,all
-      test_command: pytest -p no:warnings --pyargs acstools.tests --remote-data -v
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
 
-    secrets:
-      pypi_token: ${{ secrets.PYPI_TOKEN }}
+    - name: Install python-build and twine
+      run: python -m pip install build "twine>=3.3"
+
+    - name: Build package
+      run: python -m build --sdist --wheel .
+
+    - name: List result
+      run: ls -l dist
+
+    - name: Check dist
+      run: python -m twine check --strict dist/*
+
+    # FOR DEBUGGING ONLY: repository_url (TestPyPI) and verbose;
+    # Use appropriate token if debugging with TestPyPI
+    - name: Publish distribution 📦 to PyPI
+      if: (startsWith(github.ref, 'refs/tags/') && github.event_name == 'push')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        #repository_url: https://test.pypi.org/legacy/
+        #verbose: true


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to stop using OpenAstronomy workflow. Building simple wheel isn't that hard anyway. We can just copy paste from what I know works over at `stsynphot`.