### PR TITLE
satdet.detsat fix for scipy.stats.mode

### DIFF
--- a/acstools/satdet.py
+++ b/acstools/satdet.py
@@ -128,7 +128,6 @@ jc8m10syq_flc.fits[6] updated
 #
 
 # STDLIB
-from enum import KEEP
 import glob
 import multiprocessing
 import time


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address an error that can sometimes occur in acstools.satdet.detsat routine. This function calls scipy.stats.mode and is expecting an array as output. Historically, scipy.stats.mode always returned an array, but after v1.9.2 it returns a scalar in certain situations. Setting the keepdims keyword to True ensures the output is an array, ensuring compatibility acstools.
