### PR TITLE
update_dq improvement in findsat_mrt

### DIFF
--- a/acstools/findsat_mrt.py
+++ b/acstools/findsat_mrt.py
@@ -1360,6 +1360,11 @@ class WfcWrapper(TrailFinder):
 
         LOG.info('Rebinning the data by {}'.format(self.binsize))
 
+        # trigger a warning if the image dimensions are not even
+        if (self.image.shape[0] % self.binsize != 0) | (self.image.shape[1] % self.binsize != 0):
+            LOG.warning('Warning: image dimensions do not evenly divide by bin size.\n'
+                        'Extra rows/columns will be trimmed first')
+
         # setting a warning filter for the nansum calculations. These
         # warnings are inconsequential and already accounted for in the code
         with warnings.catch_warnings():

--- a/acstools/findsat_mrt.py
+++ b/acstools/findsat_mrt.py
@@ -1290,8 +1290,8 @@ class WfcWrapper(TrailFinder):
 
     @binsize.setter
     def binsize(self, value):
-        if value is not None and not isinstance(value, int):
-            raise ValueError(f"binsize must be None or int but got: {value}")
+        if value is not None and not (isinstance(value, int) and value >= 1):
+            raise ValueError(f"binsize must be None or int >= 1 but got: {value}")  # noqa
         self._binsize = value
 
     @property
@@ -1361,8 +1361,8 @@ class WfcWrapper(TrailFinder):
         LOG.info('Rebinning the data by {}'.format(self.binsize))
 
         # trigger a warning if the image dimensions are not even
-        if ((self.image.shape[0] % self.binsize != 0)) |
-           ((self.image.shape[1] % self.binsize != 0)):
+        if (((self.image.shape[0] % self.binsize != 0)) |
+           ((self.image.shape[1] % self.binsize != 0))):
             LOG.warning('Image dimensions do not evenly divide by bin size.'
                         '\nExtra rows/columns will be trimmed first.')
 

--- a/acstools/findsat_mrt.py
+++ b/acstools/findsat_mrt.py
@@ -1361,10 +1361,10 @@ class WfcWrapper(TrailFinder):
         LOG.info('Rebinning the data by {}'.format(self.binsize))
 
         # trigger a warning if the image dimensions are not even
-        if ((self.image.shape[0] % self.binsize != 0)) | \
+        if ((self.image.shape[0] % self.binsize != 0)) |
            ((self.image.shape[1] % self.binsize != 0)):
-            LOG.warning('Warning: image dimensions do not evenly divide by bin'
-                        'size.\n Extra rows/columns will be trimmed first')
+            LOG.warning('Image dimensions do not evenly divide by bin size.'
+                        '\nExtra rows/columns will be trimmed first.')
 
         # setting a warning filter for the nansum calculations. These
         # warnings are inconsequential and already accounted for in the code

--- a/acstools/findsat_mrt.py
+++ b/acstools/findsat_mrt.py
@@ -1361,9 +1361,10 @@ class WfcWrapper(TrailFinder):
         LOG.info('Rebinning the data by {}'.format(self.binsize))
 
         # trigger a warning if the image dimensions are not even
-        if (self.image.shape[0] % self.binsize != 0) | (self.image.shape[1] % self.binsize != 0):
-            LOG.warning('Warning: image dimensions do not evenly divide by bin size.\n'
-                        'Extra rows/columns will be trimmed first')
+        if ((self.image.shape[0] % self.binsize != 0)) | \
+           ((self.image.shape[1] % self.binsize != 0)):
+            LOG.warning('Warning: image dimensions do not evenly divide by bin'
+                        'size.\n Extra rows/columns will be trimmed first')
 
         # setting a warning filter for the nansum calculations. These
         # warnings are inconsequential and already accounted for in the code
@@ -1411,4 +1412,4 @@ class WfcWrapper(TrailFinder):
             raise ValueError(f'DQ array can only be updated for FLC/FLT images, not {self.image_type}')  # noqa
 
         update_dq(self.image_file, self.extension + 2, self.mask, dqval=dqval,
-                  verbose=verbose)
+                  verbose=verbose, expand_mask=True)

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -1218,8 +1218,8 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
                      'DQ array: {}'.format(mask.shape, dqarr.shape))
             if not expand_mask:
                 LOG.warning('Cannot proceed due to size mismatch.\n'
-                            'Set expand_mask=True if the mask was generated'
-                            'with binned data and needs to be enlarged to the'
+                            'Set expand_mask=True if the mask was generated '
+                            'with binned data and needs to be enlarged to the '
                             'original size')
                 return
             else:

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -1200,7 +1200,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
         tailored for ACS/WFC.
     verbose : bool, optional
         Print extra information to the terminal.
-    expand_mask: bool, optional
+    expand_mask : bool, optional
         Allows the mask to be expanded to match the size of the original mask.
         This is relevant for masks that were generated used binned versions of
         the original image.

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -1222,7 +1222,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
 
             if mask_larger:
                 LOG.error('Mask is larger than the DQ array in one or more '
-                          'dimensions.\nThis routine cannot currently rescale'
+                          'dimensions.\nThis routine cannot currently rescale '
                           'masks that are larger than the origin input image')
                 return
 
@@ -1246,9 +1246,19 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
                 factor_x = np.floor(dqarr.shape[1]/mask.shape[1]).astype(int)
                 factor_y = np.floor(dqarr.shape[0]/mask.shape[0]).astype(int)
                 if factor_x != factor_y:
-                    raise ValueError('Mask dimensions require scaling by'
-                                     'different amounts in order to match the'
-                                     'DQ array but this is not allowed.')
+
+                    mask_aspect = mask.shape[1]/mask.shape[0]
+                    dq_aspect = dqarr.shape[1]/dqarr.shape[0]
+
+                    raise ValueError('Mask and DQ array axis aspect ratios are'
+                                     ' too different\n'
+                                     'Mask dimensions (x,y) = {}\n'
+                                     'Mask aspect ratio (x/y) = {}\n'
+                                     'DQ array dimensions (y,x) = {}\n'
+                                     'DQ array aspect ratio (x/y) = {}'
+                                     .format(mask.shape, mask_aspect,
+                                             dqarr.shape, dq_aspect))
+
                 else:
                     factor = factor_x
 

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -1179,7 +1179,8 @@ def radon(image, theta=None, circle=False, *, preserve_range=False,
         return radon_image
 
 
-def update_dq(filename, ext, mask, dqval=16384, verbose=True, expand_mask=False):
+def update_dq(filename, ext, mask, dqval=16384, verbose=True,
+              expand_mask=False):
     """Update the given image and DQ extension with the given
     satellite trails mask and flag.
 
@@ -1212,34 +1213,40 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True, expand_mask=False)
         same_size = mask.shape == dqarr.shape
 
         if not same_size:
-            LOG.info('Inconsistent mask sizes: \n' 
-                     'Input mask: {} \n' 
+            LOG.info('Inconsistent mask sizes: \n'
+                     'Input mask: {} \n'
                      'DQ array: {}'.format(mask.shape, dqarr.shape))
             if not expand_mask:
                 LOG.warning('Cannot proceed due to size mismatch.\n'
-                            'Set expand_mask=True if the mask was generated with \n'
-                            'binned data and needs to be enlarged to the original size')
+                            'Set expand_mask=True if the mask was generated'
+                            'with binned data and needs to be enlarged to the'
+                            'original size')
                 return
             else:
                 LOG.info('Enlarging mask to original size')
                 factor_x = np.floor(dqarr.shape[1]/mask.shape[1]).astype(int)
                 factor_y = np.floor(dqarr.shape[0]/mask.shape[0]).astype(int)
-                mask = block_replicate(mask, [factor_y,factor_x], conserve_sum=False)
+                mask = block_replicate(mask, [factor_y, factor_x],
+                                       conserve_sum=False)
 
-                # for original data that had odd dimensions before binning, the 
-                # mask still will not match the original. Duplicate end rows/columns in this case
+                # for original data that had odd dimensions before binning, the
+                # mask still will not match the original. Duplicate end
+                # rows/columns in this case
 
                 same_size = mask.shape == dqarr.shape
                 if not same_size:
-                    LOG.info('Still inconsistent mask sizes: \n' 
-                             'Input mask: {} \n' 
+                    LOG.info('Still inconsistent mask sizes: \n'
+                             'Input mask: {} \n'
                              'DQ array: {}'.format(mask.shape, dqarr.shape))
-                    LOG.info('Duplicating end rows/columns to match original size')
+                    LOG.info('Duplicating end rows/columns to match orig size')
                     while mask.shape[0] != dqarr.shape[0]:
-                        mask = np.vstack([mask,mask[-1,:]])
+                        mask = np.vstack([mask,
+                                          mask[-1, :]])
 
                     while mask.shape[1] != dqarr.shape[1]:
-                        mask = np.hstack([mask,mask[:,-1].reshape(mask.shape[0],1)])
+                        mask = np.hstack([mask,
+                                          mask[:, -1].reshape(mask.shape[0],
+                                                              1)])
 
         old_mask = (dqval & dqarr) != 0  # Existing flagged trails
         new_mask = mask & ~old_mask  # Only flag previously unflagged trails

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -21,7 +21,7 @@ try:
     from skimage.transform._warps import warp
     from skimage._shared.utils import convert_to_float
 except ImportError as e:
-    warnings.warn(f'skimage not installed. MRT calculation will not work: {repr(e)}')
+    warnings.warn(f'skimage not installed. MRT calculation will not work: {repr(e)}')  # noqa
 
 # check for scipy
 try:
@@ -108,8 +108,8 @@ def merge_tables(tbls, theta_sep=10, rho_sep=10):
             drho = np.abs(t['ycentroid'] - s['ycentroid'])
             sel = (dtheta < theta_sep) & (drho < rho_sep)
             keep[sel] = False
-        # Silence MergeConflictWarning for "date" metadata because
-        # the tables were created with different timestamps. The last entry is kept.
+        # Silence MergeConflictWarning for "date" metadata because the tables
+        # were created with different timestamps. The last entry is kept.
         src = vstack([src, t[keep]], metadata_conflicts="silent")
     return src
 
@@ -1203,7 +1203,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
     expand_mask: bool, optional
         Allows the mask to be expanded to match the size of the original mask.
         This is relevant for masks that were generated used binned versions of
-        the original image. 
+        the original image.
 
     """
     with fits.open(filename, mode='update') as pf:
@@ -1211,7 +1211,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
 
         # check that the old mask and new mask are the same size
         same_size = mask.shape == dqarr.shape
-        mask_larger = np.any([mask.shape[i] > dqarr.shape[i] 
+        mask_larger = np.any([mask.shape[i] > dqarr.shape[i]
                               for i in range(mask.ndim)])
 
         # provide informative error messages depending on mask/dqarr size
@@ -1219,7 +1219,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
             LOG.info('Inconsistent mask sizes: \n'
                      'Input mask: {} \n'
                      'DQ array: {}'.format(mask.shape, dqarr.shape))
-            
+
             if mask_larger:
                 LOG.error('Mask is larger than the DQ array in one or more '
                           'dimensions.\nThis routine cannot currently rescale'
@@ -1228,27 +1228,27 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
 
             elif not mask_larger and not expand_mask:
                 LOG.error('Cannot proceed due to size mismatch.\n'
-                            'Set expand_mask=True if the mask was generated '
-                            'with binned data and needs to be enlarged to the '
-                            'original size.')
+                          'Set expand_mask=True if the mask was generated '
+                          'with binned data and needs to be enlarged to the '
+                          'original size.')
                 return
             else:
                 LOG.info('Enlarging mask to original size.')
 
-                # Determine factor by which to scale-up the image. Scales should
+                # Determine factor by which to scale-up image. Scales should
                 # be the same for the x and y dimensions, after we round down
-                # to the nearest integer in case there are extra rows/columns 
-                # that do not divide evenly. These extra rows/columns will be 
+                # to the nearest integer in case there are extra rows/columns
+                # that do not divide evenly. These extra rows/columns will be
                 # added back at the end. This approach is the reverse of
                 # astropy.nddata.block_reduce, which trims extra rows/cols
-                # first. 
+                # first.
 
                 factor_x = np.floor(dqarr.shape[1]/mask.shape[1]).astype(int)
                 factor_y = np.floor(dqarr.shape[0]/mask.shape[0]).astype(int)
                 if factor_x != factor_y:
                     raise ValueError('Mask dimensions require scaling by'
-                                     'different amounts in order to match the DQ'
-                                     'array but this is not allowed.')
+                                     'different amounts in order to match the'
+                                     'DQ array but this is not allowed.')
                 else:
                     factor = factor_x
 
@@ -1267,8 +1267,7 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
                 if extra_cols > 0:
                     LOG.info('Duplicating end columns to match orig size')
                     while mask.shape[1] != dqarr.shape[1]:
-                        mask = np.hstack([mask,
-                                          mask[:, -1].reshape(mask.shape[0],1)])
+                        mask = np.hstack([mask, mask[:, -1].reshape(mask.shape[0], 1)])  # noqa
 
         old_mask = (dqval & dqarr) != 0  # Existing flagged trails
         new_mask = mask & ~old_mask  # Only flag previously unflagged trails

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -1200,10 +1200,10 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
         tailored for ACS/WFC.
     verbose : bool, optional
         Print extra information to the terminal.
-    expand_mask: int, optional
+    expand_mask: bool, optional
         Allows the mask to be expanded to match the size of the original mask.
         This is relevant for masks that were generated used binned versions of
-        the original image
+        the original image.
 
     """
     with fits.open(filename, mode='update') as pf:
@@ -1220,10 +1220,10 @@ def update_dq(filename, ext, mask, dqval=16384, verbose=True,
                 LOG.warning('Cannot proceed due to size mismatch.\n'
                             'Set expand_mask=True if the mask was generated '
                             'with binned data and needs to be enlarged to the '
-                            'original size')
+                            'original size.')
                 return
             else:
-                LOG.info('Enlarging mask to original size')
+                LOG.info('Enlarging mask to original size.')
                 factor_x = np.floor(dqarr.shape[1]/mask.shape[1]).astype(int)
                 factor_y = np.floor(dqarr.shape[0]/mask.shape[0]).astype(int)
                 mask = block_replicate(mask, [factor_y, factor_x],


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This PR is to add in functionality to acstools.utils_findsat_mrt.updatedq to expand the input mask to match the size of the original DQ array if necessary. This is needed if a satellite trail was identified and masked on a binned image, which is common. Users could do this manually, but it is needed frequently enough that it made sense to include. This step has also been designed to handle images with odd dimensions,(e.g., WFC3/UVIS are 2051x4096) which ensures the code is applicable to other imaging data. 

Warnings have been added into acstools.findsat_mrt.TrailFinder.rebin step to inform users if their data has odd dimensions and that rows/columns were being trimmed as needed to allow rebinning (this was happening already, but users may not have been aware). These trimmed rows/columns are added back in during the update_dq step after the satellite mask is enlarged.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

