### PR TITLE
replace interp2d in utils_findsat_mrt

### DIFF
--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -26,7 +26,6 @@ except ImportError as e:
 # check for scipy
 try:
     from scipy import interpolate
-    from scipy.ndimage import map_coordinates
 except ImportError:
     warnings.warn('scipy not installed. Kernel generation will not work')
 
@@ -1433,22 +1432,23 @@ def create_mrt_line_kernel(width, sigma, outfile=None, shape=(1024, 2048),
         LOG.info('Inteprolating onto new grid to center kernel')
         theta_arr = np.arange(cutout.shape[1])
         rho_arr = np.arange(cutout.shape[0])
-        #theta_grid, rho_grid = np.meshgrid(theta_arr, rho_arr)
 
         new_theta_arr = theta_arr + theta_shift
         new_rho_arr = rho_arr + rho_shift
         new_theta_grid, new_rho_grid = np.meshgrid(new_theta_arr, new_rho_arr)
 
-        f = interpolate.RegularGridInterpolator((rho_arr, theta_arr), 
-                                                cutout.data, bounds_error=False, 
-                                                fill_value=0, method='cubic')
-        
-        # unable to provide 2D grid of points for interpolation. Switching to 
+        f = interpolate.RegularGridInterpolator((rho_arr, theta_arr),
+                                                cutout.data,
+                                                bounds_error=False,
+                                                fill_value=0,
+                                                method='cubic')
+
+        # unable to provide 2D grid of points for interpolation. Switching to
         # 1D, and then will switch back
-        points = [[r,t] for r, t in zip(np.ravel(new_rho_grid), 
-                                        np.ravel(new_theta_grid))]
-        
-        # replace the old cutout
+        points = [[r, t] for r, t in zip(np.ravel(new_rho_grid),
+                                         np.ravel(new_theta_grid))]
+
+        # return to original shape and replace the old cutout
         cutout = np.reshape(f(points), cutout.data.shape)
 
     if ax:

--- a/acstools/utils_findsat_mrt.py
+++ b/acstools/utils_findsat_mrt.py
@@ -26,6 +26,7 @@ except ImportError as e:
 # check for scipy
 try:
     from scipy import interpolate
+    from scipy.ndimage import map_coordinates
 except ImportError:
     warnings.warn('scipy not installed. Kernel generation will not work')
 
@@ -1432,16 +1433,23 @@ def create_mrt_line_kernel(width, sigma, outfile=None, shape=(1024, 2048),
         LOG.info('Inteprolating onto new grid to center kernel')
         theta_arr = np.arange(cutout.shape[1])
         rho_arr = np.arange(cutout.shape[0])
-        theta_grid, rho_grid = np.meshgrid(theta_arr, rho_arr)
+        #theta_grid, rho_grid = np.meshgrid(theta_arr, rho_arr)
 
         new_theta_arr = theta_arr + theta_shift
         new_rho_arr = rho_arr + rho_shift
         new_theta_grid, new_rho_grid = np.meshgrid(new_theta_arr, new_rho_arr)
 
-        # inteprolate onto new grid
-        f = interpolate.interp2d(theta_grid, rho_grid, cutout.data,
-                                 kind='cubic')
-        cutout = f(new_theta_arr, new_rho_arr)  # overwrite old cutout
+        f = interpolate.RegularGridInterpolator((rho_arr, theta_arr), 
+                                                cutout.data, bounds_error=False, 
+                                                fill_value=0, method='cubic')
+        
+        # unable to provide 2D grid of points for interpolation. Switching to 
+        # 1D, and then will switch back
+        points = [[r,t] for r, t in zip(np.ravel(new_rho_grid), 
+                                        np.ravel(new_theta_grid))]
+        
+        # replace the old cutout
+        cutout = np.reshape(f(points), cutout.data.shape)
 
     if ax:
         fig4, ax4 = plt.subplots()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request replaces the old interpolation method in acstools.utils_findsat_mrt.create_mrt_line_kernel from scipy.interpolate.interp2d to scipy.interpolate.RegularGridInterpolator. This request was made by Alyssa Guzman on behalf of DMD because interp2d has been deprecated and they want all packages to be compatible with the latest versions of 3rd party packages. For this update, I used scipy 1.14.1. I have tested the new interpolation method and it returns the same output as the prior method, with some slight variations, but these are very small and acceptable. 

<!-- In addition please ensure that the pull request title is descriptive. -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

