### PR TITLE
TST: Force scikit-image dev in devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,8 @@ extras =
     predeps: all
 
 commands =
+    # Force scikit-image upgrade to workaround mysterious pin in the stack.
+    devdeps: pip install scikit-image>=0.0.dev0 -U --pre -I https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     pip freeze
     pytest --pyargs acstools {toxinidir}/doc {posargs}
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/acstools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address devdeps not installing dev version of scikit-image but is blocked by:

* https://github.com/scikit-image/scikit-image/pull/8157

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->