### PR TITLE
Revert "DOC: Remove broken link for now because the CTE webtool is offline"

### DIFF
--- a/acstools/acsphotcte.py
+++ b/acstools/acsphotcte.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 The ACS Photometric CTE API is a programmatic interface for the
-ACS Photometric CTE Webtool (currently unavailable).
+`ACS Photometric CTE Webtool <https://acsphotometriccte.stsci.edu>`_.
 The API is a cloud-based service that employs a serverless approach on AWS
 with API Gateway and Lambda to compute the photometric CTE corrections
 using the model described in `ACS ISR 2022-06 <https://ui.adsabs.harvard.edu/abs/2022acs..rept....6C/abstract>`_.


### PR DESCRIPTION
Reverts spacetelescope/acstools#221

Fix #222 